### PR TITLE
Uorf new features

### DIFF
--- a/src/utrfx/uorf.py
+++ b/src/utrfx/uorf.py
@@ -90,3 +90,30 @@ def cap_five_to_uorf_distance(uorf: UORFCoordinates) -> int:
     Calculate the number of bases between the 5' cap and the uORF start codon.
     """
     return uorf.uorf.start
+
+
+def kozak_strength_sequence(five_sequence: str, uorf: UORFCoordinates) -> int:
+    """
+    Indicate the difference between a given Kozak sequence and the consensus sequence, based on two residues.
+
+    The Kozak consensus sequence is defined as CCRCCAUGG, with a purine base in position -3 and a guanine base in position +4 
+    as most important for initiation. Initiation sequence contexts are frequently classified as strong (both critical residues match the consensus sequence),
+    as adequate/intermediate (either residue -3 or +4 matches) or as weak (neither residue matches).
+
+    :returns: integer being: 2 (strong), 1 (adequate) or 0 (weak).
+
+    See here: Wethmar K, Smink JJ, Leutz A. Upstream open reading frames: molecular switches in (patho)physiology. 
+    Bioessays. 2010 Oct;32(10):885-93. doi: 10.1002/bies.201000037. Epub 2010 Aug 19. PMID: 20726009; PMCID: PMC3045505.
+    """
+    purines = ["A", "G"]
+    minus_three_residue = five_sequence[uorf.uorf.start - 3]
+    plus_four_residue = five_sequence[uorf.uorf.start + 3]
+
+    if minus_three_residue in purines and plus_four_residue == "G":
+        return 2
+    elif minus_three_residue in purines and plus_four_residue != "G":
+        return 1
+    elif minus_three_residue not in purines and plus_four_residue == "G":
+        return 1
+    else:
+        return 0

--- a/src/utrfx/uorf.py
+++ b/src/utrfx/uorf.py
@@ -85,14 +85,8 @@ def intercistronic_distance(five_sequence: str, uorf: UORFCoordinates) -> int:
     return len(five_sequence) - uorf.uorf.end
 
 
-class KozakSequenceCalculator(metaclass=abc.ABCMeta):
-
-    @abc.abstractmethod
-    def compute(self) -> float:
-        pass
-
-
-class FooKozakCalculator(KozakSequenceCalculator):
-    
-    def compute(self) -> float:
-        return 5.
+def cap_five_to_uorf_distance(uorf: UORFCoordinates) -> int:
+    """
+    Calculate the number of bases between the 5' cap and the uORF start codon.
+    """
+    return uorf.uorf.start

--- a/src/utrfx/uorf.py
+++ b/src/utrfx/uorf.py
@@ -92,7 +92,7 @@ def cap_five_to_uorf_distance(uorf: UORFCoordinates) -> int:
     return uorf.uorf.start
 
 
-def kozak_strength_sequence(five_sequence: str, uorf: UORFCoordinates) -> int:
+def kozak_sequence_strength(five_sequence: str, uorf: UORFCoordinates) -> int:
     """
     Indicate the difference between a given Kozak sequence and the consensus sequence, based on two residues.
 

--- a/tests/test_uorf.py
+++ b/tests/test_uorf.py
@@ -2,7 +2,7 @@ import pytest
 
 from utrfx.genome import Region
 from utrfx.model import FiveUTRCoordinates, UORFCoordinates
-from utrfx.uorf import gc_content, gc_content_n_bases_downstream, uorfs_plus_n_nts_downstream_extractor, intercistronic_distance, cap_five_to_uorf_distance
+from utrfx.uorf import gc_content, gc_content_n_bases_downstream, uorfs_plus_n_nts_downstream_extractor, intercistronic_distance, cap_five_to_uorf_distance, kozak_strength_sequence
 
 
 @pytest.mark.parametrize(
@@ -115,3 +115,22 @@ def test_five_cap_to_uorf_distance(
     uorf = UORFCoordinates(five_utr=hbb_five_utr, uorf=region)
 
     assert cap_five_to_uorf_distance(uorf=uorf) == expected
+
+
+@pytest.mark.parametrize(
+        "region, expected",
+        [
+            ((Region(start=16, end=67)), 2),
+            ((Region(start=302, end=407)), 1),
+            ((Region(start=510, end=576)), 1),
+        ]
+)
+def test_kozak_strength_sequence(
+    hbb_five_utr_sequence: str,
+    hbb_five_utr: FiveUTRCoordinates,
+    region: Region,
+    expected: int,
+):
+    uorf = UORFCoordinates(five_utr=hbb_five_utr, uorf=region)
+
+    assert kozak_strength_sequence(five_sequence=hbb_five_utr_sequence, uorf=uorf) == expected

--- a/tests/test_uorf.py
+++ b/tests/test_uorf.py
@@ -2,7 +2,7 @@ import pytest
 
 from utrfx.genome import Region
 from utrfx.model import FiveUTRCoordinates, UORFCoordinates
-from utrfx.uorf import gc_content, gc_content_n_bases_downstream, uorfs_plus_n_nts_downstream_extractor, intercistronic_distance, cap_five_to_uorf_distance, kozak_strength_sequence
+from utrfx.uorf import gc_content, gc_content_n_bases_downstream, uorfs_plus_n_nts_downstream_extractor, intercistronic_distance, cap_five_to_uorf_distance, kozak_sequence_strength
 
 
 @pytest.mark.parametrize(
@@ -125,7 +125,7 @@ def test_five_cap_to_uorf_distance(
             ((Region(start=510, end=576)), 1),
         ]
 )
-def test_kozak_strength_sequence(
+def test_kozak_sequence_strength(
     hbb_five_utr_sequence: str,
     hbb_five_utr: FiveUTRCoordinates,
     region: Region,
@@ -133,4 +133,4 @@ def test_kozak_strength_sequence(
 ):
     uorf = UORFCoordinates(five_utr=hbb_five_utr, uorf=region)
 
-    assert kozak_strength_sequence(five_sequence=hbb_five_utr_sequence, uorf=uorf) == expected
+    assert kozak_sequence_strength(five_sequence=hbb_five_utr_sequence, uorf=uorf) == expected

--- a/tests/test_uorf.py
+++ b/tests/test_uorf.py
@@ -2,7 +2,7 @@ import pytest
 
 from utrfx.genome import Region
 from utrfx.model import FiveUTRCoordinates, UORFCoordinates
-from utrfx.uorf import gc_content, gc_content_n_bases_downstream, uorfs_plus_n_nts_downstream_extractor, intercistronic_distance
+from utrfx.uorf import gc_content, gc_content_n_bases_downstream, uorfs_plus_n_nts_downstream_extractor, intercistronic_distance, cap_five_to_uorf_distance
 
 
 @pytest.mark.parametrize(
@@ -97,3 +97,21 @@ def test_intercistonic_distances(
     uorf = UORFCoordinates(five_utr=hbb_five_utr, uorf=region)
 
     assert intercistronic_distance(five_sequence=hbb_five_utr_sequence, uorf=uorf) == expected
+
+
+@pytest.mark.parametrize(
+        "region, expected",
+        [
+            ((Region(start=16, end=67)), 16),
+            ((Region(start=302, end=407)), 302),
+            ((Region(start=510, end=576)), 510),
+        ]
+)
+def test_five_cap_to_uorf_distance(
+    hbb_five_utr: FiveUTRCoordinates,
+    region: Region,
+    expected: int,
+):
+    uorf = UORFCoordinates(five_utr=hbb_five_utr, uorf=region)
+
+    assert cap_five_to_uorf_distance(uorf=uorf) == expected


### PR DESCRIPTION
- `cap_five_to_uorf_distance` function created, which is basically the distance between the 5' cap and the uORF start codon.

- I made a `kozak_strength_sequence` function, it is based on the paper cited in the docstring, which comments a common way to classify the Kozak sequence strength. This function can be updated if it is too simple.

- Tests for both functions work properly. 