### PR TITLE
Genomic sequence issue

### DIFF
--- a/src/utrfx/util.py
+++ b/src/utrfx/util.py
@@ -50,7 +50,7 @@ def get_five_prime_sequence(genomic_sequence: str, five_utrs: FiveUTRCoordinates
             non_five_utr_region = start - previous_end
             five_utr_sequences.append(genomic_sequence[accumulative_length + non_five_utr_region:accumulative_length + non_five_utr_region + five_utr_length])
             previous_end = end
-            accumulative_length += five_utr_length
+            accumulative_length += accumulative_length + non_five_utr_region + five_utr_length
 
     return ''.join(five_utr_sequences)
 

--- a/src/utrfx/util.py
+++ b/src/utrfx/util.py
@@ -23,14 +23,36 @@ def fetch_genomic_sequence_from_ensembl(transcript_id: str, timeout: float = 30.
         response.raise_for_status()
 
 
-def get_five_prime_sequence(cdna_sequence: str, five_utrs: FiveUTRCoordinates) -> str:
+def get_five_prime_sequence(genomic_sequence: str, five_utrs: FiveUTRCoordinates) -> str:
     """
-    Return the 5'UTR cDNA sequence of a given transcript nucleotide sequence.
+    Return the 5'UTR DNA sequence of a given transcript nucleotide sequence.
 
     :param transcript_sequence: transcript nucleotide sequence.
     :param five_utrs: 5'UTR Genomic Region(s).
     """
-    return cdna_sequence[:len(five_utrs)]
+    five_utrs_tuples = []
+    five_utr_sequences = []
+
+    for region in five_utrs.regions:
+        five_utrs_tuples.append((region.start, region.end))
+    
+    five_utrs_tuples.sort()
+    previous_end = None
+    accumulative_length = 0
+    for start,end in five_utrs_tuples:
+        five_utr_length = end - start
+        if previous_end is None:
+            five_utr_sequences.append(genomic_sequence[:five_utr_length])
+            previous_end = end
+            accumulative_length += five_utr_length
+
+        elif previous_end is not None:
+            new_start = start - previous_end
+            five_utr_sequences.append(genomic_sequence[accumulative_length + new_start:accumulative_length + new_start + five_utr_length])
+            previous_end = end
+            accumulative_length += five_utr_length
+
+    return ''.join(five_utr_sequences)
 
 
 def uorf_extractor(five_utr: FiveUTRCoordinates, five_sequence: str) -> typing.Collection[UORFCoordinates]:

--- a/src/utrfx/util.py
+++ b/src/utrfx/util.py
@@ -6,13 +6,13 @@ from utrfx.genome import Region
 from utrfx.model import FiveUTRCoordinates, UORFCoordinates
 
 
-def fetch_cdna_from_ensembl(transcript_id: str, timeout: float = 30.,) -> str:
+def fetch_genomic_sequence_from_ensembl(transcript_id: str, timeout: float = 30.,) -> str:
     """
-    Download cDNA sequence (spliced mRNA) for a given transcript from Ensembl's REST API.
+    Download the genomic sequence for a given transcript from Ensembl's REST API.
 
     :param transcript_id: Ensembl transcript identifier e.g. `ENST00000381418`
     """
-    base_url_cdna = f"https://rest.ensembl.org/sequence/id/{transcript_id}?type=cdna&content-type=text/x-fasta"
+    base_url_cdna = f"https://rest.ensembl.org/sequence/id/{transcript_id}?type=genomic&content-type=text/x-fasta"
     
     response = requests.get(base_url_cdna, timeout=timeout)
 

--- a/src/utrfx/util.py
+++ b/src/utrfx/util.py
@@ -47,8 +47,8 @@ def get_five_prime_sequence(genomic_sequence: str, five_utrs: FiveUTRCoordinates
             accumulative_length += five_utr_length
 
         elif previous_end is not None:
-            new_start = start - previous_end
-            five_utr_sequences.append(genomic_sequence[accumulative_length + new_start:accumulative_length + new_start + five_utr_length])
+            non_five_utr_region = start - previous_end
+            five_utr_sequences.append(genomic_sequence[accumulative_length + non_five_utr_region:accumulative_length + non_five_utr_region + five_utr_length])
             previous_end = end
             accumulative_length += five_utr_length
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,14 +45,12 @@ def genome_build() -> GenomeBuild:
 
 @pytest.fixture(scope="session")
 def hr_five_utr(
-    genome_build: GenomeBuild
+    genome_build: GenomeBuild,
 ) -> FiveUTRCoordinates:
     """
     5'UTR Genomic region corresponding to one of the transcripts of the HR gene (ENSEMBL transcript ID: `ENST00000381418.9`).
 
     Both Genomic Regions were obtained from the chromosome 8 GTF file.
-
-    see here: https://www.ensembl.org/Homo_sapiens/Transcript/Summary?db=core;g=ENSG00000168453;r=8:22114419-22133384;t=ENST00000381418
     """
     contig = genome_build.contig_by_name("8")
     assert contig is not None

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,7 @@
 import pytest
 
 from utrfx.model import FiveUTRCoordinates
-from utrfx.util import fetch_cdna_from_ensembl, uorf_extractor
+from utrfx.util import fetch_genomic_sequence_from_ensembl, uorf_extractor
 
 
 @pytest.mark.online
@@ -18,7 +18,7 @@ def test_fetch_cdna_from_ensembl(
      end: str,
      n_bases: int,
 ):
-     cdna = fetch_cdna_from_ensembl(tx_id)
+     cdna = fetch_genomic_sequence_from_ensembl(tx_id)
      assert cdna.startswith(start)
      assert cdna.endswith(end)
      assert len(cdna) == n_bases

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,11 +8,11 @@ from utrfx.util import fetch_genomic_sequence_from_ensembl, uorf_extractor
 @pytest.mark.parametrize(
      "tx_id, start, end, n_bases",
      [
-          ("ENST00000696628", "GGTCGTTCCC", "CTATTTGAAA", 2_412), # tx on the + strand
-          ("ENST00000381418", "AGTTGCGCTT", "ATAAGGGTAA", 5_474), # tx on the - strand
+          ("ENST00000696628", "GGTCGTTCCC", "CTATTTGAAA", 14_770), # tx on the + strand
+          ("ENST00000381418", "AGTTGCGCTT", "ATAAGGGTAA", 16_592), # tx on the - strand
      ]
 )
-def test_fetch_cdna_from_ensembl(
+def test_fetch_genomic_sequence_from_ensembl(
      tx_id: str,
      start: str,
      end: str,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,14 +1,13 @@
 import pytest
 
 from utrfx.model import FiveUTRCoordinates
-from utrfx.util import fetch_genomic_sequence_from_ensembl, uorf_extractor
-
+from utrfx.util import fetch_genomic_sequence_from_ensembl, uorf_extractor, get_five_prime_sequence
 
 @pytest.mark.online
 @pytest.mark.parametrize(
      "tx_id, start, end, n_bases",
      [
-          ("ENST00000696628", "GGTCGTTCCC", "CTATTTGAAA", 14_770), # tx on the + strand
+          ("ENST00000650287", "GTCAGACTCG", "TATTACCACA", 28_007), # tx on the + strand
           ("ENST00000381418", "AGTTGCGCTT", "ATAAGGGTAA", 16_592), # tx on the - strand
      ]
 )
@@ -22,6 +21,28 @@ def test_fetch_genomic_sequence_from_ensembl(
      assert cdna.startswith(start)
      assert cdna.endswith(end)
      assert len(cdna) == n_bases
+
+
+@pytest.mark.online
+def test_get_five_prime_sequence(
+     lpl_five_utr: FiveUTRCoordinates,
+):
+     genomic_sequence = fetch_genomic_sequence_from_ensembl("ENST00000650287") 
+     five_utr_sequence = get_five_prime_sequence(genomic_sequence, lpl_five_utr) # tx on the + strand
+     assert five_utr_sequence.startswith("GTCAGACTCG")
+     assert five_utr_sequence.endswith("GCGCCCCGAG")
+     assert len(five_utr_sequence) == 188
+
+
+@pytest.mark.online
+def test_get_five_prime_sequence(
+     hr_five_utr: FiveUTRCoordinates,
+):
+     genomic_sequence = fetch_genomic_sequence_from_ensembl("ENST00000381418")
+     five_utr_sequence = get_five_prime_sequence(genomic_sequence, hr_five_utr) # tx on the - strand
+     assert five_utr_sequence.startswith("AGTTGCGCTT")
+     assert five_utr_sequence.endswith("CAGGAGAGTG")
+     assert len(five_utr_sequence) == 623
 
 
 def test_uorf_extractor(

--- a/tests/test_variant_util.py
+++ b/tests/test_variant_util.py
@@ -57,3 +57,29 @@ def test_msh2_variant(
     assert len(genomic_sequence) + 1 == len(variant_genomic_sequence)
     assert genomic_sequence[:43] == variant_genomic_sequence[:43]
     assert genomic_sequence[-10:] == variant_genomic_sequence[-10:]
+
+
+@pytest.mark.online
+def test_lpl_variant(
+    lpl_variant: VariantCoordinates, # Variant not in 5'UTR
+    lpl_five_utr: FiveUTRCoordinates,
+):
+    genomic_sequence = fetch_genomic_sequence_from_ensembl("ENST00000650287")
+
+    with pytest.raises(AssertionError) as e:
+        prepare_alt_seq(lpl_variant, genomic_sequence, lpl_five_utr)
+
+    assert e.value.args == ("Variant not in the 5'UTR of the given transcript.",)
+
+
+@pytest.mark.online
+def test_lpl_variant(
+    lpl_fake_variant: VariantCoordinates, # Invented variant that does not match its position
+    lpl_five_utr: FiveUTRCoordinates,
+):
+    genomic_sequence = fetch_genomic_sequence_from_ensembl("ENST00000650287")
+
+    with pytest.raises(AssertionError) as e:
+        prepare_alt_seq(lpl_fake_variant, genomic_sequence, lpl_five_utr)
+
+    assert e.value.args == ("Reference do not match the position.",)


### PR DESCRIPTION
- Changed the `fetch_cdna_from_ensembl` to `fetch_genomic_sequence_from_ensembl` just adjusting the url.

-  Uptdated the `get_five_prime_sequence` this way:

Stored the `start` and `end` of each 5'UTR `Genomic Regions` in tuples within a list. Sort the list and for the first one (I make sure of this with the `previous_end` = `None`), the `genomic sequence` is spliced accordingly and kept in a `five_utr_sequences` list. The length of this region is saved in the `accumulative_length` variable to be used in the next loop.
For instance, a second 5'UTR region would go through the loop and a new start would be set, being this the distance between the end of the first 5'UTR region and the start of this second one (remember these numbers correspond to its position in the genome, for example 12_300_456) plus the accumulated length. Therefore, the next step in this loop would be cut the sequence skiping the `non_five_utr_region` (which is the previous calculated distance) and taking into account this second 5'UTR length.
Finally, a new end and the accumulative length would be updated, coming another loop or returning the corresponding 5'UTR genomic sequence as a `string`.

- **Tests**:

1.  Update the `fetch_genomic_sequence_from_ensembl` tests.
2. Created tests for `get_five_prime_sequence`.
3. Make tests for `prepare_alt_seq` work and added two `AssertionError` tests.
4. All tests work.
5. One question: Is it out of scope using the `fetch_genomic_sequence_from_ensembl` inside the `prepare_alt_seq` tests? Should they be put as a fixture? I didn't want to copy the whole genomic sequence of each gene in the `conftest` file to save memory, but I don't know if accesing to the server each time is proper work.