### PR TITLE
Extend test suite for UTRs on negative strand

### DIFF
--- a/src/utrfx/variant_util.py
+++ b/src/utrfx/variant_util.py
@@ -29,7 +29,7 @@ def prepare_alt_seq(
         variant_region_start = variant.start
     else:
         ref = variant.ref.translate(str.maketrans("ATCG", "TAGC"))
-        alt = variant.alt
+        alt = variant.alt.translate(str.maketrans("ATCG", "TAGC"))
         variant_region_start = variant.region.with_strand(gene_strand).start
 
     in_variant = any(region.overlaps_with(variant.region) for region in five_utrs.regions)

--- a/tests/test_variant_util.py
+++ b/tests/test_variant_util.py
@@ -43,7 +43,7 @@ class TestPrepareAltSeq:
     def cdna_seq(self) -> str:
         """
         40 bases corresponding to a fake cDNA sequence
-        of the 5'UTR region of a fake transcript on the positive strand.
+        of the 5'UTR region of a fake transcript.
 
         The sequence originates from the bases (10,50]
         of the `TestPrepareAltSeq.CONTIG`.
@@ -161,9 +161,8 @@ class TestPrepareAltSeq:
         actual = prepare_alt_seq(vc, cdna_seq, five_utr_coordinates_forward)
         assert actual == expected
 
-
     class TestNegativeStrand:
-        
+
         @pytest.fixture(scope="class")
         def five_utr_coordinates_negative(self) -> FiveUTRCoordinates:
             return FiveUTRCoordinates(
@@ -182,13 +181,12 @@ class TestPrepareAltSeq:
                     ),
                 )
             )
-        
+
         @pytest.fixture(scope="class")
         def cdna_seq_negative(self) -> str:
             """
             25 bases corresponding to a fake cDNA sequence
             of the 5'UTR region of a fake transcript on the negative strand.
-
             The sequence originates from the bases
             spanned by (5,15](-) (20,35](-)
             regions of the `TestPrepareAltSeq.CONTIG`.
@@ -238,7 +236,7 @@ class TestPrepareAltSeq:
 
             #               *
             #     ref:  GGGGGCCCCCTTTTTAAAAACCCCC
-            expected = "GGGGTGCCCCCTTTTTAAAAACCCCC"
+            expected = "GGGGGTCCCCCTTTTTAAAAACCCCC"
             actual = prepare_alt_seq(vc, cdna_seq_negative, five_utr_coordinates_negative)
             assert actual == expected
 
@@ -247,11 +245,11 @@ class TestPrepareAltSeq:
             cdna_seq_negative: str,
             five_utr_coordinates_negative: FiveUTRCoordinates,
         ):
-            vc = TestPrepareAltSeq.make_variant(70, "GT", "GAC")
+            vc = TestPrepareAltSeq.make_variant(70, "TG", "GAC")
 
-            #                               *
+            #                              **
             #     ref:  GGGGGCCCCCTTTTTAAAAACCCCC
-            expected = "GGGGGCCCCCTTTTTAAAAGTCCCCC"
+            expected = "GGGGGCCCCCTTTTTAAAACTGCCCC"
             actual = prepare_alt_seq(vc, cdna_seq_negative, five_utr_coordinates_negative)
             assert actual == expected
 
@@ -277,7 +275,7 @@ def test_hr_variant_one(
     vc = prepare_alt_seq(hr_variant_one, hr_five_utr_sequence, hr_five_utr)
 
     assert hr_five_utr_sequence[405] == "A"
-    assert vc[405] == "C"
+    assert vc[405] == "G"
 
 def test_hr_variant_two(
     hr_variant_two: VariantCoordinates,
@@ -287,7 +285,7 @@ def test_hr_variant_two(
     vc = prepare_alt_seq(hr_variant_two, hr_five_utr_sequence, hr_five_utr)
 
     assert hr_five_utr_sequence[321] == "C"
-    assert vc[321] == "T"
+    assert vc[321] == "A"
 
 def test_hr_variant_three(
     hr_variant_three: VariantCoordinates,
@@ -297,7 +295,7 @@ def test_hr_variant_three(
     vc = prepare_alt_seq(hr_variant_three, hr_five_utr_sequence, hr_five_utr)
 
     assert hr_five_utr_sequence[308] == "C"
-    assert vc[308] == "A"
+    assert vc[308] == "T"
 
 def test_hr_variant_four(
     hr_variant_four: VariantCoordinates,
@@ -307,4 +305,4 @@ def test_hr_variant_four(
     vc = prepare_alt_seq(hr_variant_four, hr_five_utr_sequence, hr_five_utr)
 
     assert hr_five_utr_sequence[302] == "A"
-    assert vc[302] == "C"
+    assert vc[302] == "G"

--- a/tests/test_variant_util.py
+++ b/tests/test_variant_util.py
@@ -43,7 +43,7 @@ class TestPrepareAltSeq:
     def cdna_seq(self) -> str:
         """
         40 bases corresponding to a fake cDNA sequence
-        of the 5'UTR region of a fake transcript.
+        of the 5'UTR region of a fake transcript on the positive strand.
 
         The sequence originates from the bases (10,50]
         of the `TestPrepareAltSeq.CONTIG`.
@@ -160,6 +160,100 @@ class TestPrepareAltSeq:
         expected = "AAAAACCCCCGGGGGTTTTTAAAAATCCCGGGGGTTTTT"
         actual = prepare_alt_seq(vc, cdna_seq, five_utr_coordinates_forward)
         assert actual == expected
+
+
+    class TestNegativeStrand:
+        
+        @pytest.fixture(scope="class")
+        def five_utr_coordinates_negative(self) -> FiveUTRCoordinates:
+            return FiveUTRCoordinates(
+                regions=(
+                    GenomicRegion(
+                        TestPrepareAltSeq.CONTIG,
+                        start=5,
+                        end=15,
+                        strand=Strand.NEGATIVE,
+                    ),
+                    GenomicRegion(
+                        TestPrepareAltSeq.CONTIG,
+                        start=20,
+                        end=35,
+                        strand=Strand.NEGATIVE,
+                    ),
+                )
+            )
+        
+        @pytest.fixture(scope="class")
+        def cdna_seq_negative(self) -> str:
+            """
+            25 bases corresponding to a fake cDNA sequence
+            of the 5'UTR region of a fake transcript on the negative strand.
+
+            The sequence originates from the bases
+            spanned by (5,15](-) (20,35](-)
+            regions of the `TestPrepareAltSeq.CONTIG`.
+            """
+            # Genomic coordinates (1-based):
+            # 
+            #        5'UTR (1)        5'UTR (2)
+            #       6       15    21            35
+            #       |        |     |             |
+            #       |        |     |             |
+            #       |        |     |             |
+            #       v        v     v             v
+            return "GGGGGCCCCC" + "TTTTTAAAAACCCCC"
+
+        def test_snp(
+            self,
+            cdna_seq_negative: str,
+            five_utr_coordinates_negative: FiveUTRCoordinates,
+        ):
+            vc = TestPrepareAltSeq.make_variant(91, "C", "A")
+
+            #               *
+            #     ref:  GGGGGCCCCCTTTTTAAAAACCCCC
+            expected = "GGGGTCCCCCTTTTTAAAAACCCCC"
+            actual = prepare_alt_seq(vc, cdna_seq_negative, five_utr_coordinates_negative)
+            assert actual == expected
+
+        def test_del(
+            self,
+            cdna_seq_negative: str,
+            five_utr_coordinates_negative: FiveUTRCoordinates,
+        ):
+            vc = TestPrepareAltSeq.make_variant(91, "CC", "C")
+
+            #              **
+            #     ref:  GGGGGCCCCCTTTTTAAAAACCCCC
+            expected = "GGGGCCCCCTTTTTAAAAACCCCC"
+            actual = prepare_alt_seq(vc, cdna_seq_negative, five_utr_coordinates_negative)
+            assert actual == expected
+
+        def test_ins(
+            self,
+            cdna_seq_negative: str,
+            five_utr_coordinates_negative: FiveUTRCoordinates,
+        ):
+            vc = TestPrepareAltSeq.make_variant(91, "C", "CA")
+
+            #               *
+            #     ref:  GGGGGCCCCCTTTTTAAAAACCCCC
+            expected = "GGGGTGCCCCCTTTTTAAAAACCCCC"
+            actual = prepare_alt_seq(vc, cdna_seq_negative, five_utr_coordinates_negative)
+            assert actual == expected
+
+        def test_mnv(
+            self,
+            cdna_seq_negative: str,
+            five_utr_coordinates_negative: FiveUTRCoordinates,
+        ):
+            vc = TestPrepareAltSeq.make_variant(70, "GT", "GAC")
+
+            #                               *
+            #     ref:  GGGGGCCCCCTTTTTAAAAACCCCC
+            expected = "GGGGGCCCCCTTTTTAAAAGTCCCCC"
+            actual = prepare_alt_seq(vc, cdna_seq_negative, five_utr_coordinates_negative)
+            assert actual == expected
 
     @staticmethod
     def make_variant(


### PR DESCRIPTION
Hi, I added some tests for a toy UTR that is on the negative strand.

I think this makes the test suite basically complete and I am "almost" sure that the expected outcomes are reasonable.

However, not all tests currently pass, which means that the `prepare_alt_seq` still needs work.

Please merge this PR into your branch and then work on the function so that the tests pass.

Could you please have a look? Thanks!