### PR TITLE
Util uorf improvements

### DIFF
--- a/src/utrfx/model.py
+++ b/src/utrfx/model.py
@@ -92,7 +92,8 @@ class UORFCoordinates:
     def __eq__(self, other):
         return (isinstance(other, UORFCoordinates)
                 and self._five_utr== other._five_utr
-                and self._uorf == other._uorf)
+                and self._uorf == other._uorf
+                and self._ouorf == other._ouorf)
     
     def __repr__(self) -> str:
         return f"UORFCoordinates(Five_UTRs= {len(self._five_utr.regions)}, uORF= {self._uorf}, ouORF= {self._ouorf})"

--- a/src/utrfx/model.py
+++ b/src/utrfx/model.py
@@ -69,15 +69,22 @@ class UORFCoordinates:
         self,
         five_utr: FiveUTRCoordinates,
         uorf: Region,
+        ouorf: bool,
     ):
         assert isinstance(five_utr, FiveUTRCoordinates)
         self._five_utr = five_utr
         assert isinstance(uorf, Region)
         self._uorf = uorf
+        assert isinstance(ouorf, bool)
+        self._ouorf = ouorf
 
     @property
     def uorf(self) -> Region:
         return self._uorf
+    
+    @property
+    def ouorf(self) -> bool:
+        return self._ouorf
 
     def __len__(self) -> int:
         return len(self._uorf.end - self._uorf.start)  
@@ -88,4 +95,4 @@ class UORFCoordinates:
                 and self._uorf == other._uorf)
     
     def __repr__(self) -> str:
-        return f"UORFCoordinates(Five_UTRs= {len(self._five_utr.regions)}, uORF= {self._uorf})"
+        return f"UORFCoordinates(Five_UTRs= {len(self._five_utr.regions)}, uORF= {self._uorf}, ouORF= {self._ouorf})"

--- a/src/utrfx/model.py
+++ b/src/utrfx/model.py
@@ -60,10 +60,11 @@ class UORFCoordinates:
     """
     `UORFCoordinates` represents an uORF of a transcript.
 
-    The UORF is upstream of the mORF and they do *not* overlap.
+    The UORF is upstream of the mORF.
 
     :param transcript: transcript with its corresponding identifier and 5'UTR Genomic Region(s).
     :param uorf: uORF region marked by its start and end nucleotide.
+    :param ouorf: boolean indicating if the uORF overlaps with the mORF.
     """
     def __init__(
         self,

--- a/src/utrfx/util.py
+++ b/src/utrfx/util.py
@@ -70,6 +70,6 @@ def uorf_extractor(five_utr: FiveUTRCoordinates, five_sequence: str) -> typing.C
                 uorf=Region(start=start_index, end=len(five_sequence)),
                 ouorf= True,
             ))
-            start_position = start_index + 3  
+            start_position = start_index + 1  
 
     return uorfs

--- a/src/utrfx/util.py
+++ b/src/utrfx/util.py
@@ -35,8 +35,7 @@ def get_five_prime_sequence(cdna_sequence: str, five_utrs: FiveUTRCoordinates) -
 
 def uorf_extractor(five_utr: FiveUTRCoordinates, five_sequence: str) -> typing.Collection[UORFCoordinates]:
     """
-    Take the cDNA nucleotide sequence of a transcript 5'UTR region to extract the uORFs sequences available
-    (not those overlapping with the main ORF).
+    Take the cDNA nucleotide sequence of a transcript 5'UTR region to extract the uORFs sequences available.
 
     :param five_utr: list of Genomic Regions corresponding to the 5'UTRs regions.
     :param five_sequence: 5'UTR cDNA sequence.

--- a/src/utrfx/util.py
+++ b/src/utrfx/util.py
@@ -60,10 +60,16 @@ def uorf_extractor(five_utr: FiveUTRCoordinates, five_sequence: str) -> typing.C
         if found_stop:
             uorfs.append(UORFCoordinates(
                 five_utr=five_utr,
-                uorf=Region(start=start_index, end=stop_index)
+                uorf=Region(start=start_index, end=stop_index),
+                ouorf= False,
             ))
             start_position = stop_index  
         else:
+            uorfs.append(UORFCoordinates(
+                five_utr=five_utr,
+                uorf=Region(start=start_index, end=len(five_sequence)),
+                ouorf= True,
+            ))
             start_position = start_index + 3  
 
     return uorfs

--- a/tests/test_uorf.py
+++ b/tests/test_uorf.py
@@ -19,7 +19,7 @@ def test_gc_content(
     region: Region, 
     expected: float,
 ):
-    uorf = UORFCoordinates(five_utr=hr_five_utr, uorf=region)
+    uorf = UORFCoordinates(five_utr=hr_five_utr, uorf=region, ouorf= False)
     result = gc_content(five_sequence=hr_five_utr_sequence, uorf=uorf)
     
     assert result == pytest.approx(expected, rel=1e-6)
@@ -29,7 +29,7 @@ def test_uorf_ends_out_of_five_prime(
     hr_five_utr_sequence: str,
     hr_five_utr: FiveUTRCoordinates,
 ):
-    overlapping_uorf = UORFCoordinates(five_utr=hr_five_utr, uorf=Region(start=700, end=800))
+    overlapping_uorf = UORFCoordinates(five_utr=hr_five_utr, uorf=Region(start=700, end=800), ouorf=True)
 
     with pytest.raises(ValueError) as e:
         gc_content(five_sequence=hr_five_utr_sequence, uorf=overlapping_uorf)
@@ -38,13 +38,13 @@ def test_uorf_ends_out_of_five_prime(
 
 
 @pytest.mark.parametrize(
-        "region, bases, expected",
+        "region, bases, ouorf, expected",
         [
-            ((Region(start=16, end=67)), 10, ((4+5)/10)),
-            ((Region(start=302, end=407)), 10, ((3+6)/10)),
-            ((Region(start=510, end=576)), 10, ((4+3)/10)),
-            ((Region(start=510, end=576)), 700, ((18+15)/47)), # Number of bases out of 5'UTR region,
-            ((Region(start=510, end=576)), 8500, ((18+15)/47)), # so the GC content remains the same, clipped to 47 bases
+            ((Region(start=16, end=67)), 10, False, ((4+5)/10)),
+            ((Region(start=302, end=407)), 10, False, ((3+6)/10)),
+            ((Region(start=510, end=576)), 10, False, ((4+3)/10)),
+            ((Region(start=510, end=576)), 700, True, ((18+15)/47)), # Number of bases out of 5'UTR region,
+            ((Region(start=510, end=576)), 8500, True, ((18+15)/47)), # so the GC content remains the same, clipped to 47 bases
         ]
 )
 def test_gc_content_n_bases_downstream(
@@ -52,22 +52,23 @@ def test_gc_content_n_bases_downstream(
     hr_five_utr: FiveUTRCoordinates,
     region: Region,
     bases: int,
+    ouorf: bool,
     expected: float, 
 ):
-    uorf = UORFCoordinates(five_utr=hr_five_utr, uorf=region)
+    uorf = UORFCoordinates(five_utr=hr_five_utr, uorf=region, ouorf=ouorf)
     result = gc_content_n_bases_downstream(five_sequence=hr_five_utr_sequence, uorf=uorf, bases=bases) 
 
     assert result == pytest.approx(expected, rel=1e-6)
 
 
 @pytest.mark.parametrize(
-        "region, bases, expected",
+        "region, bases, ouorf, expected",
         [
-            ((Region(start=16, end=67)), 10, 61),
-            ((Region(start=302, end=407)), 10, 115),
-            ((Region(start=510, end=576)), 10, 76),
-            ((Region(start=510, end=576)), 700, 113), 
-            ((Region(start=510, end=576)), 8500, 113),
+            ((Region(start=16, end=67)), 10, False, 61),
+            ((Region(start=302, end=407)), 10, False, 115),
+            ((Region(start=510, end=576)), 10, False, 76),
+            ((Region(start=510, end=576)), 700, True, 113), 
+            ((Region(start=510, end=576)), 8500, True, 113),
         ]
 )
 def test_uorfs_plus_nts_downstream(
@@ -75,9 +76,10 @@ def test_uorfs_plus_nts_downstream(
     hr_five_utr: FiveUTRCoordinates,
     region: Region,
     bases: int,
+    ouorf: bool,
     expected: float,
 ):
-    uorf = UORFCoordinates(five_utr=hr_five_utr, uorf=region)
+    uorf = UORFCoordinates(five_utr=hr_five_utr, uorf=region, ouorf=ouorf)
 
     assert len(uorfs_plus_n_nts_downstream_extractor(five_sequence=hr_five_utr_sequence, uorf=uorf, bases=bases)) == expected
 
@@ -96,7 +98,7 @@ def test_intercistronic_distances(
     region: Region,
     expected: int,
 ):
-    uorf = UORFCoordinates(five_utr=hr_five_utr, uorf=region)
+    uorf = UORFCoordinates(five_utr=hr_five_utr, uorf=region, ouorf=False)
 
     assert intercistronic_distance(five_sequence=hr_five_utr_sequence, uorf=uorf) == expected
 
@@ -114,25 +116,27 @@ def test_five_cap_to_uorf_distance(
     region: Region,
     expected: int,
 ):
-    uorf = UORFCoordinates(five_utr=hr_five_utr, uorf=region)
+    uorf = UORFCoordinates(five_utr=hr_five_utr, uorf=region, ouorf=False)
 
     assert cap_five_to_uorf_distance(uorf=uorf) == expected
 
 
 @pytest.mark.parametrize(
-        "region, expected",
+        "region, ouorf, expected",
         [
-            ((Region(start=16, end=67)), 2),
-            ((Region(start=302, end=407)), 1),
-            ((Region(start=510, end=576)), 1),
+            ((Region(start=16, end=67)), False, 2),
+            ((Region(start=302, end=407)), False, 1),
+            ((Region(start=510, end=576)), False, 1),
+            ((Region(start=606, end=623)), True, 0)
         ]
 )
 def test_kozak_sequence_strength(
     hr_five_utr_sequence: str,
     hr_five_utr: FiveUTRCoordinates,
     region: Region,
+    ouorf: bool,
     expected: int,
 ):
-    uorf = UORFCoordinates(five_utr=hr_five_utr, uorf=region)
+    uorf = UORFCoordinates(five_utr=hr_five_utr, uorf=region, ouorf=ouorf)
 
     assert kozak_sequence_strength(five_sequence=hr_five_utr_sequence, uorf=uorf) == expected

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -29,15 +29,22 @@ def test_uorf_extractor(
     hr_five_utr_sequence: str,
 ):
     uorfs = uorf_extractor(five_utr=hr_five_utr, five_sequence=hr_five_utr_sequence)
-    assert len(uorfs) == 3
+    assert len(uorfs) == 4
 
-    first_uorf, second_uorf, third_uorf = uorfs
+    first_uorf, second_uorf, third_uorf , fourth_uorf = uorfs
 
     assert first_uorf.uorf.start == 16
     assert first_uorf.uorf.end == 67
+    assert first_uorf.ouorf == False
 
     assert second_uorf.uorf.start == 302
     assert second_uorf.uorf.end == 407
+    assert second_uorf.ouorf == False
 
     assert third_uorf.uorf.start == 510
     assert third_uorf.uorf.end == 576
+    assert third_uorf.ouorf == False
+                    
+    assert fourth_uorf.uorf.start == 606
+    assert fourth_uorf.uorf.end == 623
+    assert fourth_uorf.ouorf == True


### PR DESCRIPTION
- Create `ouORF` parameter to handle possible overlapping uORFs. As once we talked, this could be a good way to work with overlapping uORFs and I think it improves the readability and comparability of results.

- Adjust tests.

