### PR TITLE
Use `VCFfile` as a context manager to ensure proper resource management

### DIFF
--- a/src/utrfx/variant_util.py
+++ b/src/utrfx/variant_util.py
@@ -129,7 +129,3 @@ class VCFfile:
             for alt in rec.alts:
                 variant_list.append(VariantCoordinates.from_vcf_literal(contig=contig, pos=pos, ref=ref, alt=alt))
         return variant_list
-    
-    def close_vcf(self):
-        # TODO: remove
-        return self._vcf_file.close()

--- a/src/utrfx/variant_util.py
+++ b/src/utrfx/variant_util.py
@@ -71,7 +71,10 @@ def reverse_complement(seq: str) -> str:
 class VCFfile:
     """
     `VCFfile` represents a VCF file and allow to search for specific variants within it.
+
+    The object must be used as a context manager to ensure proper resource cleanup.
     """
+
     def __init__(
         self,
         vcf_fpath: str,
@@ -110,7 +113,14 @@ class VCFfile:
         contig: Contig, 
         start: int,
         end: int,
-    ) -> typing.Collection[VariantCoordinates]: 
+    ) -> typing.Collection[VariantCoordinates]:
+        """
+        Get variant for the query region.
+
+        :param contig: the query region contig.
+        :param start: 0-based (excluded) start coordinate of the query region.
+        :param start: 0-based (included) end coordinate of the query region.
+        """
         assert self._vcf_file is not None, "VCFfile must be used as a context manager"
         variant_list = []
         for rec in self._vcf_file.fetch(contig.ucsc_name, start, end):

--- a/src/utrfx/variant_util.py
+++ b/src/utrfx/variant_util.py
@@ -3,7 +3,7 @@ import os
 
 import pysam
 
-from utrfx.genome import VariantCoordinates, Strand, Contig, Region
+from utrfx.genome import VariantCoordinates, Strand, Contig
 from utrfx.model import FiveUTRCoordinates
 
 def prepare_alt_seq(
@@ -76,21 +76,42 @@ class VCFfile:
         self,
         vcf_fpath: str,
     ):
-        self._vcf_fpath = vcf_fpath
-        self._vcf_file = self._open_vcf()
+        self._vcf_fpath, self._vcf_tbi_fpath = VCFfile._check_path(vcf_fpath)
+        self._vcf_file = None
+
+    @staticmethod
+    def _check_path(fpath) -> typing.Tuple[str, str]:
+        if os.path.isfile(fpath):
+            index_fpath = fpath + ".tbi"
+            if os.path.isfile(index_fpath):
+                return fpath, index_fpath
+            else:
+                raise ValueError(f"`{index_fpath}` is not a file")
+        else:
+            raise ValueError(f"`{fpath}` is not a file")
 
     def _open_vcf(self):
-        index_fpath = self._vcf_fpath + ".tbi"
-        if not os.path.exists(index_fpath):
-            pysam.tabix_index(self._vcf_fpath, preset="vcf")
-        return pysam.VariantFile(self._vcf_fpath, "r")
+        return pysam.VariantFile(
+            self._vcf_fpath,
+            mode="r",
+            index_filename=self._vcf_tbi_fpath,
+        )
     
+    def __enter__(self) -> "VCFfile":
+        self._vcf_file = self._open_vcf()
+        return self
+    
+    def __exit__(self, _exc_type, _exc_value, _exc_traceback):
+        self._vcf_file.close()
+        self._vcf_file = None
+
     def retrieve_variants_of_region(
         self, 
         contig: Contig, 
         start: int,
         end: int,
     ) -> typing.Collection[VariantCoordinates]: 
+        assert self._vcf_file is not None, "VCFfile must be used as a context manager"
         variant_list = []
         for rec in self._vcf_file.fetch(contig.ucsc_name, start, end):
             pos = rec.pos
@@ -102,4 +123,5 @@ class VCFfile:
         return variant_list
     
     def close_vcf(self):
+        # TODO: remove
         return self._vcf_file.close()

--- a/src/utrfx/variant_util.py
+++ b/src/utrfx/variant_util.py
@@ -116,10 +116,8 @@ class VCFfile:
         for rec in self._vcf_file.fetch(contig.ucsc_name, start, end):
             pos = rec.pos
             ref = rec.ref
-            alts = rec.alts 
-            if alts[0] is not None:
-                alt = alts[0]
-            variant_list.append(VariantCoordinates.from_vcf_literal(contig=contig, pos=pos, ref=ref, alt=alt))
+            for alt in rec.alts:
+                variant_list.append(VariantCoordinates.from_vcf_literal(contig=contig, pos=pos, ref=ref, alt=alt))
         return variant_list
     
     def close_vcf(self):

--- a/tests/test_variant_util.py
+++ b/tests/test_variant_util.py
@@ -280,19 +280,48 @@ class TestPrepareAltSeq:
         )
     
 
-@pytest.fixture(scope="session")
-def vcf_fpath(fpath_data_dir: str) -> str:
-    return os.path.join(fpath_data_dir, "gnomad.genomes.v4.1.sites.chr8.sample.vcf.gz")
+class TestVCFFile:
 
-@pytest.fixture(scope="session")
-def vcf_file(vcf_fpath: str) -> VCFfile:
-    return VCFfile(vcf_fpath=vcf_fpath)
+    @pytest.fixture(scope="class")
+    def vcf_fpath(self, fpath_data_dir: str) -> str:
+        return os.path.join(fpath_data_dir, "gnomad.genomes.v4.1.sites.chr8.sample.vcf.gz")
 
 
-def test_variants_in_region(genome_build: GenomeBuild, vcf_file: VCFfile):
-    contig = genome_build.contig_by_name("8")
-    variants_list = vcf_file.retrieve_variants_of_region(contig=contig, start=22_130_610, end=22_130_650)
+    def test_retrieve_variants_of_region(
+        self,
+        genome_build: GenomeBuild,
+        vcf_fpath: str,
+    ):
+        contig = genome_build.contig_by_name("8")
+        with VCFfile(vcf_fpath) as vcf_fh:
+            variants = vcf_fh.retrieve_variants_of_region(contig=contig, start=22_130_651, end=22_130_692)
 
-    assert len(variants_list) == 9
+        assert len(variants) == 9
+        
+        # We're getting a collection but we'd like to check the first and last variant.
+        # Therefore, let's wrap the collection into a tuple to simplify testing.
+        variants = tuple(variants)
 
-    vcf_file.close_vcf()
+        first = variants[0]
+        assert first.start == 22_130_651
+        assert first.end == 22_130_652
+
+        last = variants[-1]
+        assert last.start == 22_130_691
+        assert last.end == 22_130_692
+
+    def test_raises_if_not_used_as_a_context_manager(
+        self,
+        genome_build: GenomeBuild,
+        vcf_fpath: str,
+    ):
+        vcf = VCFfile(vcf_fpath=vcf_fpath)
+        
+        contig = genome_build.contig_by_name("8")
+        assert contig is not None
+
+        with pytest.raises(AssertionError) as e:
+            _ = vcf.retrieve_variants_of_region(contig=contig, start=22_130_651, end=22_130_692)
+            
+        assert e.value.args == ("VCFfile must be used as a context manager",)
+        


### PR DESCRIPTION
`VCFfile` uses a closeable resource under the hood and closing these resources is a good practice. However, it is possible for the users to "forget" to close if closing is done in a bespoke method.

In Python, this is a use case for a context manager, where file is open during `__enter__` method, and closed in `__exit__`.  The methods are called automatically, if used with the `with ... as ...` syntax.

This PR refactors the `VCFfile` into a context manager. The example usage is shown in the tests.

Moreover, I changed the coordinates of the test region to test an edge case. The test VCF file includes adjacent variants at positions `chr8:22,130,651` and `chr8:22,130,652`. The updated test region coordinates check that we only get the latter variant.